### PR TITLE
Fix chatbot 404 error and improve response routing logic

### DIFF
--- a/app/chatbot/page.tsx
+++ b/app/chatbot/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "./chat/page"

--- a/lib/club-faq.ts
+++ b/lib/club-faq.ts
@@ -40,6 +40,18 @@ function scoreMatch(queryNorm: string, pattern: string) {
   return Math.round((hit / Math.max(words.length, 1)) * 80);
 }
 
+// ===== Club-related Detection =====
+const clubKeywords = [
+  'clb', 'cau lac bo', 'ftc', 'fintech club', 'uel', 'ung tuyen', 'tham gia',
+  'hoat dong', 'sinh hoat', 'ban', 'mentor', 'thuc tap', 'tuyen dung',
+  'su kien', 'chuong trinh', 'lien he', 'fanpage', 'email', 'moneywe'
+];
+
+export function isClubRelated(question: string): boolean {
+  const q = normalizeVi(question);
+  return clubKeywords.some((kw) => q.includes(normalizeVi(kw)));
+}
+
 // ===== FAQ Dataset (đã gộp & mở rộng pattern) =====
 const faq: ClubFaqItem[] = [
   // 1) Giới thiệu CLB
@@ -106,7 +118,7 @@ Thông báo chi tiết trên fanpage và website trước sự kiện ≥7 ngày
     answer:
 `💳 **Chi phí**: không thu phí thành viên bắt buộc.
 Một số chuyên đề có thể thu mức phí nhỏ để bù chi phí;
-thành viên tích cực thường được ưu tiên miễn/giảm.`,
+thành viên tích cực thường ��ược ưu tiên miễn/giảm.`,
   },
 
   // 7) Kỹ năng / yêu cầu
@@ -137,7 +149,7 @@ thực hành giao dịch theo thuật toán (kèm nguyên tắc quản trị r�
 Cơ hội xây hồ sơ năng lực, được giới thiệu thực tập.`,
   },
 
-  // 10) Cơ hội thực tập
+  // 10) C�� hội thực tập
   {
     patterns: ['thuc tap', 'co hoi thuc tap', 'tuyen dung', 'gioi thieu thuc tap', 'internship', 'career'],
     answer:


### PR DESCRIPTION
## Purpose
The user requested to fix a 404 error on the chatbot page and improve the chatbot's response system. The goal was to restructure the chatbot's answer logic so that club-related questions are handled by the existing FAQ system with fallback responses, while non-club-related questions are routed to the Gemini API for general responses.

## Code changes
- **Fixed 404 error**: Added `app/chatbot/page.tsx` that exports the chat page component to resolve routing issues
- **Enhanced response logic**: Added `isClubRelated()` function in `lib/club-faq.ts` to detect club-related questions using keyword matching
- **Improved routing**: Modified `app/chatbot/api/chat/gemini/route.ts` to:
  - Import the new `isClubRelated` function
  - Restructure the decision flow to first check if questions are club-related
  - Route club-related questions to fallback responses when FAQ doesn't match
  - Route non-club-related questions to Gemini API for general responses
- **Updated logic flow**: Changed from industry-domain routing to club-relevance classification for better question handling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/46d5a76bcdf74882b4c0e93066770d94/aura-realm)

👀 [Preview Link](https://46d5a76bcdf74882b4c0e93066770d94-aura-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>46d5a76bcdf74882b4c0e93066770d94</projectId>-->
<!--<branchName>aura-realm</branchName>-->